### PR TITLE
Use 64-byte buffers for registers (closes #3)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Changes
 =======
 
+1.0b6 (unreleased)
+------------------
+
+* Completely fixed buffer overflow when reading registers over 64 bits. (Closes `issue #3`_)
+
+.. _issue #3: https://github.com/dargueta/unicorn-lua/issues/3
+
 1.0b5 (2019-10-23)
 ------------------
 

--- a/include/unicornlua/registers.h
+++ b/include/unicornlua/registers.h
@@ -11,6 +11,16 @@
 
 
 /**
+ * Define a buffer large enough to hold the largest registers available.
+ *
+ * We need 64 bytes to be able to hold a 512-bit ZMM register. For now, only the
+ * low 32 or 64 bits are accessible to Lua. Eventually we'll figure out how to
+ * use the rest.
+*/
+typedef char register_buffer_type[64];
+
+
+/**
  * Write to an architecture register.
  */
 int ul_reg_write(lua_State *L);

--- a/src/registers.cpp
+++ b/src/registers.cpp
@@ -7,6 +7,7 @@
 #include "unicornlua/compat.h"
 #include "unicornlua/engine.h"
 #include "unicornlua/lua.h"
+#include "unicornlua/registers.h"
 #include "unicornlua/utils.h"
 
 
@@ -23,15 +24,17 @@ int ul_reg_write(lua_State *L) {
 
 
 int ul_reg_read(lua_State *L) {
-    uint_least64_t value = 0;
+    register_buffer_type value_buffer;
+    memset(value_buffer, 0, sizeof(value_buffer));
+
     uc_engine *engine = ul_toengine(L, 1);
     int register_id = luaL_checkinteger(L, 2);
 
-    uc_err error = uc_reg_read(engine, register_id, &value);
+    uc_err error = uc_reg_read(engine, register_id, value_buffer);
     if (error != UC_ERR_OK)
         return ul_crash_on_error(L, error);
 
-    lua_pushinteger(L, value);
+    lua_pushinteger(L, *reinterpret_cast<lua_Integer *>(value_buffer));
     return 1;
 }
 
@@ -80,7 +83,7 @@ int ul_reg_read_batch(lua_State *L) {
     int n_registers = lua_gettop(L) - 1;
 
     std::unique_ptr<int[]> register_ids(new int[n_registers]);
-    std::unique_ptr<int_least64_t[]> values(new int_least64_t[n_registers]);
+    std::unique_ptr<register_buffer_type[]> values(new register_buffer_type[n_registers]);
     std::unique_ptr<void *[]> p_values(new void *[n_registers]);
 
     for (int i = 0; i < n_registers; ++i) {
@@ -88,7 +91,7 @@ int ul_reg_read_batch(lua_State *L) {
         p_values[i] = &values[i];
     }
 
-    memset(values.get(), 0, n_registers * sizeof(int_least64_t));
+    memset(values.get(), 0, n_registers * sizeof(register_buffer_type));
     uc_err error = uc_reg_read_batch(
         engine, register_ids.get(), p_values.get(), n_registers
     );
@@ -96,7 +99,7 @@ int ul_reg_read_batch(lua_State *L) {
         return ul_crash_on_error(L, error);
 
     for (int i = 0; i < n_registers; ++i)
-        lua_pushinteger(L, values[i]);
+        lua_pushinteger(L, *reinterpret_cast<lua_Integer *>(values[i]));
 
     return n_registers;
 }


### PR DESCRIPTION
Allows reading the largest known registers without a buffer overflow. Lua still won't be able to access the upper bits beyond its architecture (32/64 bits depending on the build) but we can work on that later.