### PR TITLE
(Maybe) fix test crashes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,14 @@ on: [ push ]
 jobs:
   testing:
     runs-on: ${{ matrix.operating-system }}
+    env:
+      # We need the MACOSX_DEPLOYMENT_TARGET environment variable because of
+      # a linker error that happens with LuaJIT:
+      # https://github.com/LuaJIT/LuaJIT/issues/449
+      MACOSX_DEPLOYMENT_TARGET: 10.14
+      # We get a linker error if we don't mess with the library path. For some
+      # reason, /usr/lib64 isn't on the default search path.
+      LD_LIBRARY_PATH: /usr/lib64:${LD_LIBRARY_PATH}
     strategy:
       fail-fast: false
       matrix:
@@ -26,21 +34,12 @@ jobs:
       - name: Install Unicorn
         run: ./tools/ci/install-unicorn.sh 1.0.2
       - name: Set up Lua
-        # We need the MACOSX_DEPLOYMENT_TARGET environment variable because of
-        # a linker error that happens with LuaJIT:
-        # https://github.com/LuaJIT/LuaJIT/issues/449
-        run: |
-          export MACOSX_DEPLOYMENT_TARGET=10.14
-          python3 ./tools/lua_venv.py -l -o settings.json ${{ matrix.lua-version }} __lua${{ matrix.lua-version }}
+        run: python3 ./tools/lua_venv.py -l -o settings.json ${{ matrix.lua-version }} .venv
       - name: Configure build
         run: python3 ./configure --venv-config settings.json --build-type debug
       - name: Install
         run: sudo make install
       - name: Run tests
-        # We get a linker error if we don't mess with the library path. For some
-        # reason, /usr/lib64 isn't on the default search path.
-        run: |
-          export LD_LIBRARY_PATH=/usr/lib64:${LD_LIBRARY_PATH}
-          make test
+        run: make test
 
   # TODO (dargueta): Test on Windows?

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,17 @@
 Changes
 =======
 
+1.2.2 (2021-11-22)
+------------------
+
+Bugfixes
+~~~~~~~~
+
+Crashes with a more accurate error message if you try double-freeing a context.
+Before, the engine handle was checked first and the error message said this was
+a bug in the library -- which was misleading. Now, it checks the *context handle*
+first, and correctly determines if you've double-freed the context.
+
 1.2.1 (2021-11-21)
 ------------------
 
@@ -14,6 +25,17 @@ Bugfixes
 Compilation fails in Visual Studio because of an unguarded use of ``__attribute__``,
 which is specific to GCC and GCC-compatible compilers. This release adds a
 preprocessor guard to prevent syntax errors.
+
+Other Changes
+~~~~~~~~~~~~~
+
+* Randomized the order of C++ tests on each run.
+* Stricter checks on the stack when testing.
+* If the stack is dirty when a test exits, this now shows the size of the stack
+  and the types of the elements on it.
+* Bumped default version of LuaRocks from 3.7 to 3.8.
+* Fixed dependency specifications in the Makefile which were hella broken.
+* Fixed environment variables in CI to allow use on Windows without modification.
 
 1.2.0 (2021-08-11)
 ------------------

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,13 @@ all: $(BUILD_DIR)
 
 .PHONY: clean
 clean:
-	cmake -E rm -rf $(DOXYGEN_OUTPUT_BASE) $(BUILD_DIR) $(VIRTUALENV_DIR) core* *.in configuration.cmake
+	$(MAKE) -C $(BUILD_DIR) clean
+	cmake -E rm -rf $(DOXYGEN_OUTPUT_BASE) core*
 
+
+.PHONY: pristine
+pristine: clean
+	cmake -E rm -rf $(VIRTUALENV_DIR) *.in configuration.cmake
 
 $(BUILD_DIR):
 	cmake -S $(REPO_ROOT) -B $(BUILD_DIR) -DCMAKE_VERBOSE_MAKEFILE=YES
@@ -23,8 +28,10 @@ $(SHARED_LIB_FILE): $(BUILD_DIR)
 	$(MAKE) -C $(BUILD_DIR) unicornlua_library
 
 
-$(TEST_EXE_FILE): $(SHARED_LIB_FILE) $(TEST_SOURCES)
+.PHONY: test
+test: $(SHARED_LIB_FILE) $(TEST_SOURCES) $(BUSTED_EXE)
 	$(MAKE) -C $(BUILD_DIR) cpp_test
+	$(MAKE) -C $(BUILD_DIR) test "ARGS=--output-on-failure -VV"
 
 
 .PHONY: install
@@ -39,15 +46,6 @@ docs:
 
 .PHONY: examples
 examples: $(X86_BINARY_IMAGES) $(SHARED_LIB_FILE)
-
-
-.PHONY: test
-test: $(BUILT_LIBRARY_DIRECTORY)/.test-sentinel
-
-
-$(BUILT_LIBRARY_DIRECTORY)/.test-sentinel: $(TEST_EXE_FILE) $(BUSTED_EXE)
-	cmake -E touch $@
-	$(MAKE) -C $(BUILD_DIR) test "ARGS=--output-on-failure -VV"
 
 
 $(BUSTED_EXE):

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ include Makefile.in
 EXAMPLES_ROOT=$(REPO_ROOT)/examples
 X86_BINARY_IMAGES=$(X86_ASM_SOURCE_FILES:%.asm=%.x86.bin)
 MIPS_BINARY_IMAGES=$(MIPS_ASM_SOURCE_FILES:%.s=%.mips32.bin)
+LIBRARY_SOURCES=$(wildcard src/*.cpp) $(wildcard include/unicornlua/*.h)
+TEST_SOURCES=$(wildcard tests/c/*.cpp) $(wildcard tests/c/*.h) $(wildcard tests/lua/*.lua)
 
 
 .PHONY: all
@@ -24,13 +26,16 @@ $(BUILD_DIR):
 	cmake -S $(REPO_ROOT) -B $(BUILD_DIR) -DCMAKE_VERBOSE_MAKEFILE=YES
 
 
-$(SHARED_LIB_FILE): $(BUILD_DIR)
+$(SHARED_LIB_FILE): $(LIBRARY_SOURCES) | $(BUILD_DIR)
 	$(MAKE) -C $(BUILD_DIR) unicornlua_library
 
 
-.PHONY: test
-test: $(SHARED_LIB_FILE) $(TEST_SOURCES) $(BUSTED_EXE)
+$(TEST_EXE_FILE): $(SHARED_LIB_FILE) $(TEST_SOURCES)
 	$(MAKE) -C $(BUILD_DIR) cpp_test
+
+
+.PHONY: test
+test: $(TEST_EXE_FILE) $(TEST_SOURCES) $(BUSTED_EXE)
 	$(MAKE) -C $(BUILD_DIR) test "ARGS=--output-on-failure -VV"
 
 

--- a/include/unicornlua/lua.h
+++ b/include/unicornlua/lua.h
@@ -9,4 +9,4 @@ extern "C" {
 #include <lua.h>
 }
 
-#include "unicornlua/compat.h"
+#include "compat.h"

--- a/include/unicornlua/unicornlua.h
+++ b/include/unicornlua/unicornlua.h
@@ -30,7 +30,7 @@
 /**
  * The patch version number of this Lua library (third part, x.x.1).
  */
-#define UNICORNLUA_VERSION_PATCH    1
+#define UNICORNLUA_VERSION_PATCH    2
 
 /**
  * Create a 24-bit number from a release's major, minor, and patch numbers.

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -52,6 +52,8 @@ int ul_context_restore(lua_State *L) {
 int ul_context_free(lua_State *L) {
     Context *context = get_context_struct(L, 1);
 
+    if (context->context_handle == nullptr)
+        throw LuaBindingError("Attempted to free the same context twice.");
     if (context->engine == nullptr)
         throw LuaBindingError("BUG: Engine was collected before the context.");
 

--- a/tests/c/CMakeLists.txt
+++ b/tests/c/CMakeLists.txt
@@ -35,4 +35,4 @@ target_link_libraries(
     cpp_test LINK_PUBLIC unicornlua_library ${UNICORN_LIBRARY} ${PTHREADS_LIBRARY} ${LUA_LIBRARIES}
 )
 
-add_test(NAME cpp_unit_tests COMMAND cpp_test)
+add_test(NAME cpp_unit_tests COMMAND cpp_test --order-by=rand)

--- a/tests/c/context.cpp
+++ b/tests/c/context.cpp
@@ -73,10 +73,6 @@ TEST_CASE_FIXTURE(AutoclosingEngineFixture, "Closing a closed context explodes."
     REQUIRE_EQ(context->context_handle, nullptr);
     REQUIRE_EQ(context->engine, nullptr);
 
-    // Ensure the context is still at the top of the stack
-    REQUIRE_EQ(lua_gettop(L), 1);
-    CHECK_EQ(lua_type(L, 1), LUA_TUSERDATA);
-
     // Ensure that the context is still on top of the stack, then try freeing
     // it again.
     REQUIRE_EQ(lua_gettop(L), 1);
@@ -84,7 +80,6 @@ TEST_CASE_FIXTURE(AutoclosingEngineFixture, "Closing a closed context explodes."
     CHECK_THROWS_AS(ul_context_free(L), LuaBindingError);
 
     // Remove the context from the stack.
-    CHECK_EQ(lua_gettop(L), 1);
     lua_pop(L, 1);
 }
 
@@ -117,11 +112,11 @@ TEST_CASE_FIXTURE(AutoclosingEngineFixture, "Trying to restore from a closed con
     CHECK_NE(context, nullptr);
 
     ul_context_free(L);
-    REQUIRE_EQ(context->context_handle, nullptr);
-    REQUIRE_EQ(context->engine, nullptr);
+    CHECK_EQ(context->context_handle, nullptr);
+    CHECK_EQ(context->engine, nullptr);
 
     auto userdata = reinterpret_cast<Context *>(lua_touserdata(L, -1));
-    REQUIRE_EQ(userdata, context);
+    CHECK_EQ(userdata, context);
     CHECK_THROWS_AS(uclua_engine->restore_from_context(context), LuaBindingError);
 
     // Remove the context from the stack.

--- a/tests/c/context.cpp
+++ b/tests/c/context.cpp
@@ -71,11 +71,25 @@ TEST_CASE_FIXTURE(AutoclosingEngineFixture, "Closing a closed context explodes."
 
     ul_context_free(L);
     REQUIRE_EQ(context->context_handle, nullptr);
-    CHECK_EQ(context->engine, nullptr);
+    REQUIRE_EQ(context->engine, nullptr);
+
+    // Ensure the context is still at the top of the stack
+    REQUIRE_EQ(lua_gettop(L), 1);
+
+    ul_context_free(L);
+    REQUIRE_EQ(context->context_handle, nullptr);
+
+    // Ensure that the context is still on top of the stack, then try freeing
+    // it again.
+    REQUIRE_EQ(lua_gettop(L), 1);
     CHECK_THROWS_AS(ul_context_free(L), LuaBindingError);
 
     // Remove the context from the stack.
+    REQUIRE_EQ(lua_gettop(L), 1);
     lua_pop(L, 1);
+
+    // For some reason this seems to be misbehaving
+    CHECK_MESSAGE(lua_gettop(L) == 0, "(DEBUG) lua_pop() didn't work as expected.");
 }
 
 

--- a/tests/c/context.cpp
+++ b/tests/c/context.cpp
@@ -75,21 +75,17 @@ TEST_CASE_FIXTURE(AutoclosingEngineFixture, "Closing a closed context explodes."
 
     // Ensure the context is still at the top of the stack
     REQUIRE_EQ(lua_gettop(L), 1);
-
-    ul_context_free(L);
-    REQUIRE_EQ(context->context_handle, nullptr);
+    CHECK_EQ(lua_type(L, 1), LUA_TUSERDATA);
 
     // Ensure that the context is still on top of the stack, then try freeing
     // it again.
     REQUIRE_EQ(lua_gettop(L), 1);
+    REQUIRE_EQ(lua_type(L, 1), LUA_TUSERDATA);
     CHECK_THROWS_AS(ul_context_free(L), LuaBindingError);
 
     // Remove the context from the stack.
-    REQUIRE_EQ(lua_gettop(L), 1);
+    CHECK_EQ(lua_gettop(L), 1);
     lua_pop(L, 1);
-
-    // For some reason this seems to be misbehaving
-    CHECK_MESSAGE(lua_gettop(L) == 0, "(DEBUG) lua_pop() didn't work as expected.");
 }
 
 

--- a/tests/c/fixtures.cpp
+++ b/tests/c/fixtures.cpp
@@ -1,3 +1,5 @@
+#include <sstream>
+
 #include <unicorn/unicorn.h>
 
 #include "doctest.h"
@@ -18,6 +20,14 @@ LuaFixture::~LuaFixture() {
         return;
 
     CHECK_MESSAGE(lua_gettop(L) == 0, "Garbage left on the stack after test exited.");
+    if (lua_gettop(L) > 0) {
+        std::ostringstream buf;
+        for (int i = 1; i <= lua_gettop(L); ++i) {
+            const char *type_name = lua_typename(L, i);
+            buf << "At stack index " << i << ": " << type_name << "\n";
+        }
+        FAIL(buf.str().c_str());
+    }
     lua_close(L);
 }
 

--- a/tests/c/fixtures.cpp
+++ b/tests/c/fixtures.cpp
@@ -35,15 +35,21 @@ LuaFixture::~LuaFixture() {
 EngineFixture::EngineFixture() : LuaFixture(), uclua_engine(nullptr)
 {
     ul_init_engines_lib(L);
-    REQUIRE_MESSAGE(lua_gettop(L) == 0, "Garbage left on the stack.");
+    CHECK_MESSAGE(
+        lua_gettop(L) == 0,
+        "Garbage left on the stack after initializing the engine system."
+    );
 
     uc_engine *engine_handle;
     uc_err error = uc_open(UC_ARCH_X86, UC_MODE_32, &engine_handle);
     REQUIRE_MESSAGE(error == UC_ERR_OK, "Failed to create an x86-32 engine.");
 
     uclua_engine = new UCLuaEngine(L, engine_handle);
-    REQUIRE(uclua_engine->get_handle() != nullptr);
-    REQUIRE(lua_gettop(L) == 0);
+    CHECK_NE(uclua_engine->get_handle(), nullptr);
+    CHECK_MESSAGE(
+        lua_gettop(L) == 0,
+        "Garbage on the stack after creating the engine object."
+    );
 }
 
 
@@ -51,5 +57,13 @@ AutoclosingEngineFixture::~AutoclosingEngineFixture() {
     // This REQUIRE shouldn't be necessary but we're getting segfaults in LuaJIT
     // but only on OSX. I'm at my wits' end trying to figure this out.
     REQUIRE(L != nullptr);
+    CHECK_MESSAGE(
+        lua_gettop(L) == 0,
+        "Trash on the stack just BEFORE deleting the engine C++ object"
+    );
     delete uclua_engine;
+    CHECK_MESSAGE(
+        lua_gettop(L) == 0,
+        "Trash on the stack AFTER deleting the engine C++ object."
+    );
 }

--- a/tests/c/fixtures.cpp
+++ b/tests/c/fixtures.cpp
@@ -28,8 +28,8 @@ EngineFixture::EngineFixture() : LuaFixture(), uclua_engine(nullptr)
     REQUIRE_MESSAGE(lua_gettop(L) == 0, "Garbage left on the stack.");
 
     uc_engine *engine_handle;
-    uc_err error = uc_open(UC_ARCH_MIPS, UC_MODE_32, &engine_handle);
-    REQUIRE_MESSAGE(error == UC_ERR_OK, "Failed to create a MIPS engine.");
+    uc_err error = uc_open(UC_ARCH_X86, UC_MODE_32, &engine_handle);
+    REQUIRE_MESSAGE(error == UC_ERR_OK, "Failed to create an x86-32 engine.");
 
     uclua_engine = new UCLuaEngine(L, engine_handle);
     REQUIRE(uclua_engine->get_handle() != nullptr);

--- a/tools/lua_settings.ini
+++ b/tools/lua_settings.ini
@@ -32,4 +32,4 @@ default_version = 5.3
 
 [luarocks]
 ; The default version of LuaRocks to install if not specified by the user.
-default_version = 3.7.0
+default_version = 3.8.0


### PR DESCRIPTION
* MIPS test engine appears to be broken somehow, switch engines to stop spurious crashes
* Make `make clean` less aggressive but provide a new `pristine` target that exhibits the old behavior
* Add additional checks in the C++ unit tests.