### PR TITLE
Fix MSVC incompatibility

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,20 @@
 Changes
 =======
 
+1.2.1 (2021-11-21)
+------------------
+
+This is functionally identical to 1.2.0 but fixes a compilation problem on
+Microsoft Visual C++. Special thanks to `Metaworm <https://github.com/metaworm>`_
+for finding this.
+
+Bugfixes
+~~~~~~~~
+
+Compilation fails in Visual Studio because of an unguarded use of ``__attribute__``,
+which is specific to GCC and GCC-compatible compilers. This release adds a
+preprocessor guard to prevent syntax errors.
+
 1.2.0 (2021-08-11)
 ------------------
 

--- a/include/unicornlua/unicornlua.h
+++ b/include/unicornlua/unicornlua.h
@@ -30,7 +30,7 @@
 /**
  * The patch version number of this Lua library (third part, x.x.1).
  */
-#define UNICORNLUA_VERSION_PATCH    0
+#define UNICORNLUA_VERSION_PATCH    1
 
 /**
  * Create a 24-bit number from a release's major, minor, and patch numbers.

--- a/src/registers.cpp
+++ b/src/registers.cpp
@@ -48,7 +48,9 @@ lua_Number read_float80(const uint8_t *data) {
                     return static_cast<lua_Number>(sign ? -INFINITY : +INFINITY);
 
                 // Significand is non-zero, fall through to next case.
+                #ifndef _MSC_VER
                 __attribute__ ((fallthrough));
+                #endif
             case 1:
                 /* 8087 - 80287 treat this as a signaling NaN, 80387 and later
                  * treat this as an invalid operand and will explode. Compromise


### PR DESCRIPTION
This breaks on Visual Studio because of an unguarded use of `__attribute__`. Thanks to [Metaworm](https://github.com/metaworm) for pointing this out.